### PR TITLE
Methods: streamlined error message creation for exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ def failing_method
    1/0
 rescue => e
    result.exception = e
-   result.error_message = e.to_s
 ensure
    return result
 end
@@ -266,12 +265,25 @@ result.error_message       #=> "divided by 0"
 result.exception           #=> #<ZeroDivisionError: divided by 0>
 result.exception.backtrace #=> [..........]
 ```
+> **Note:** <br/>`:error_message` is set automatically if not previously set.
 
 <a name='error_message'></a>
 ### :error_message
 
+
 The `:error_message` allows for a readable error message, and can be
-used even when there is no exeption recorded. (see above example)
+used even when there is no exeption recorded.
+
+```ruby
+def test_method
+   result = ResultVault.new
+   result.error_message = "Test message"
+   return result
+end
+
+result = test_method
+result.error_message    #=> "Test message"
+```
 
 
 <a name='data'></a>

--- a/lib/result_vault.rb
+++ b/lib/result_vault.rb
@@ -202,7 +202,8 @@ class ResultVault
 
     when :exception
       _assert_valid_exception(val)
-      @exception = val
+      @exception     = val
+      @error_message = exception.to_s if [nil, ""].include?(@error_message)
 
     when :success, :ok, :good, :pass, :passed, :succeeded
       @success = !!val

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe ResultVault, type: :model do
       it "sets the exception value" do
         expect{result.exception= ArgumentError.new}.not_to raise_error
       end
+
+      it "updates the error message if blank" do
+        result.exception= ArgumentError.new
+        expect(result.error_message).to eq(result.exception.to_s)
+      end
+
+      it "leaves an existing error message unchanged" do
+        result.error_message = "Test message"
+        result.exception= ArgumentError.new
+        expect(result.error_message).to eq("Test message")
+      end
     end # :exception=
 
 


### PR DESCRIPTION
Automatically add the exceptions error message when adding an exception, if the vault's error message is blank